### PR TITLE
feat: update to JavaScript SDK v0.0.0-pre.4 and rename apiKey to sdkKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ types/
 dist/
 coverage/
 *.tgz
+.envrc

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const WrappedApp = () => {
   };
 
   return (
-    <ReforgeProvider apiKey={"YOUR_API_KEY"} contextAttributes={context} onError={onError}>
+    <ReforgeProvider sdkKey={"YOUR_SDK_KEY"} contextAttributes={context} onError={onError}>
       <App />
     </ReforgeProvider>
   );
@@ -39,7 +39,7 @@ Here's an explanation of each provider prop:
 
 | property            | required | type                | purpose                                                                       |
 | ------------------- | -------- | ------------------- | ----------------------------------------------------------------------------- |
-| `apiKey`            | yes      | `string`            | your Reforge API key                                                          |
+| `sdkKey`            | yes      | `string`            | your Reforge SDK key                                                          |
 | `onError`           | no       | `(error) => void`   | callback invoked if reforge fails to initialize                               |
 | `contextAttributes` | no       | `ContextAttributes` | this is the context attributes object you passed when setting up the provider |
 | `endpoints`         | no       | `string[]`          | CDN endpoints to load configuration from (defaults to 2 reforge-based CDNs)   |

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "config"
   ],
   "dependencies": {
-    "@reforge-com/javascript": "0.0.0-pre.3"
+    "@reforge-com/javascript": "0.0.0-pre.4"
   },
   "devDependencies": {
-    "@reforge-com/javascript": "^0.0.0-pre.3",
+    "@reforge-com/javascript": "^0.0.0-pre.4",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@types/jest": "^28.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.9.2",
   "name": "@reforge-com/react",
-  "version": "0.0.0-pre.5",
+  "version": "0.0.0-pre.6",
   "description": "Feature Flags & Dynamic Configuration as a Service",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/src/ReforgeProvider.tsx
+++ b/src/ReforgeProvider.tsx
@@ -38,7 +38,7 @@ type ClassMethods<T> = { [K in keyof T]: T[K] };
 type ReforgeTypesafeClass<T = unknown> = new (reforgeInstance: Reforge) => T;
 
 type SharedSettings = {
-  apiKey?: string;
+  sdkKey?: string;
   endpoints?: string[];
   apiEndpoint?: string;
   timeout?: number;
@@ -112,7 +112,7 @@ export const assignReforgeClient = () => {
 };
 
 export type ReforgeProviderProps = SharedSettings & {
-  apiKey: string;
+  sdkKey: string;
   contextAttributes?: ContextAttributes;
   ReforgeTypesafeClass?: ReforgeTypesafeClass<any>;
 };
@@ -167,7 +167,7 @@ export const extractTypesafeMethods = (
 };
 
 function ReforgeProvider({
-  apiKey,
+  sdkKey,
   contextAttributes = {},
   onError = (e: unknown) => {
     // eslint-disable-next-line no-console
@@ -185,7 +185,7 @@ function ReforgeProvider({
   ReforgeTypesafeClass: TypesafeClass,
 }: PropsWithChildren<ReforgeProviderProps>) {
   const settings = {
-    apiKey,
+    sdkKey,
     endpoints,
     apiEndpoint,
     timeout,
@@ -221,8 +221,8 @@ function ReforgeProvider({
       if (mostRecentlyLoadingContextKey.current === undefined) {
         mostRecentlyLoadingContextKey.current = contextKey;
 
-        if (!apiKey) {
-          throw new Error("ReforgeProvider: apiKey is required");
+        if (!sdkKey) {
+          throw new Error("ReforgeProvider: sdkKey is required");
         }
 
         const initOptions: Parameters<typeof reforgeClient.init>[0] = {
@@ -265,7 +265,7 @@ function ReforgeProvider({
       onError(e as Error);
     }
   }, [
-    apiKey,
+    sdkKey,
     loadedContextKey,
     contextKey,
     loading,

--- a/src/ReforgeTestProvider.tsx
+++ b/src/ReforgeTestProvider.tsx
@@ -9,11 +9,11 @@ import {
 
 export type ReforgeTestProviderProps = {
   config: Record<string, any>;
-  apiKey?: string;
+  sdkKey?: string;
 };
 
 function ReforgeTestProvider({
-  apiKey,
+  sdkKey,
   config,
   children,
   ReforgeTypesafeClass: TypesafeClass,
@@ -45,7 +45,7 @@ function ReforgeTestProvider({
       loading: false,
       reforge: reforgeClient,
       keys: Object.keys(config),
-      settings: { apiKey: apiKey ?? "fake-api-key-via-the-test-provider" },
+      settings: { sdkKey: sdkKey ?? "fake-sdk-key-via-the-test-provider" },
     };
 
     if (typesafeInstance) {
@@ -54,7 +54,7 @@ function ReforgeTestProvider({
     }
 
     return baseContext;
-  }, [config, reforgeClient, typesafeInstance, apiKey]);
+  }, [config, reforgeClient, typesafeInstance, sdkKey]);
 
   return <ReforgeContext.Provider value={value}>{children}</ReforgeContext.Provider>;
 }

--- a/src/__tests__/ReforgeProvider.test.tsx
+++ b/src/__tests__/ReforgeProvider.test.tsx
@@ -69,7 +69,7 @@ describe("ReforgeProvider", () => {
     onError?: (err: Error) => void;
   }) =>
     render(
-      <ReforgeProvider apiKey="api-key" contextAttributes={contextAttributes} onError={onError}>
+      <ReforgeProvider sdkKey="sdk-key" contextAttributes={contextAttributes} onError={onError}>
         <MyComponent />
       </ReforgeProvider>
     );
@@ -181,7 +181,7 @@ describe("ReforgeProvider", () => {
     act(() => {
       rendered.rerender(
         <ReforgeProvider
-          apiKey="api-key"
+          sdkKey="sdk-key"
           contextAttributes={{ user: { email: "test@example.com" } }}
           onError={() => {}}
         >
@@ -213,7 +213,7 @@ describe("ReforgeProvider", () => {
       setContextAttributes = innerSetContextAttributes;
 
       return (
-        <ReforgeProvider apiKey="api-key" contextAttributes={contextAttributes} onError={() => {}}>
+        <ReforgeProvider sdkKey="sdk-key" contextAttributes={contextAttributes} onError={() => {}}>
           <MyComponent />
         </ReforgeProvider>
       );
@@ -252,7 +252,7 @@ describe("ReforgeProvider", () => {
 
     render(
       <ReforgeProvider
-        apiKey="api-key"
+        sdkKey="sdk-key"
         contextAttributes={context}
         afterEvaluationCallback={callback}
         onError={() => {}}
@@ -314,7 +314,7 @@ describe("ReforgeProvider with TypesafeClass", () => {
   it("makes TypesafeClass methods available through useReforgeTypesafe", async () => {
     render(
       <ReforgeProvider
-        apiKey="test-api-key"
+        sdkKey="test-sdk-key"
         contextAttributes={defaultContextAttributes}
         ReforgeTypesafeClass={AppConfig}
       >
@@ -337,7 +337,7 @@ describe("ReforgeProvider with TypesafeClass", () => {
   it("provides typesafe methods through the custom hook", async () => {
     render(
       <ReforgeProvider
-        apiKey="test-api-key"
+        sdkKey="test-sdk-key"
         contextAttributes={defaultContextAttributes}
         ReforgeTypesafeClass={AppConfig}
       >
@@ -368,7 +368,7 @@ describe("ReforgeProvider with TypesafeClass", () => {
 
     render(
       <ReforgeProvider
-        apiKey="test-api-key"
+        sdkKey="test-sdk-key"
         contextAttributes={defaultContextAttributes}
         ReforgeTypesafeClass={AppConfig}
       >
@@ -536,7 +536,7 @@ describe("createReforgeHook functionality with ReforgeProvider", () => {
   it("creates a working custom hook with createReforgeHook", async () => {
     render(
       <ReforgeProvider
-        apiKey="test-api-key"
+        sdkKey="test-sdk-key"
         ReforgeTypesafeClass={CustomFeatureFlags}
         contextAttributes={defaultContextAttributes}
       >
@@ -610,7 +610,7 @@ describe("createReforgeHook functionality with ReforgeProvider", () => {
 
     render(
       <ReforgeProvider
-        apiKey="test-api-key"
+        sdkKey="test-sdk-key"
         contextAttributes={defaultContextAttributes}
         ReforgeTypesafeClass={SpiedClass}
       >

--- a/src/__tests__/nested-providers.test.tsx
+++ b/src/__tests__/nested-providers.test.tsx
@@ -15,7 +15,7 @@ enableFetchMocks();
 
 // eslint-disable-next-line no-console
 const onError = console.error;
-const apiKey = "nested-providers-test-api-key";
+const sdkKey = "nested-providers-test-sdk-key";
 
 function InnerUserComponent() {
   const { isEnabled, loading, reforge, settings } = useReforge();
@@ -80,7 +80,7 @@ function OuterUserComponent({
         <ReforgeProvider
           {...innerSettings}
           contextAttributes={innerUserContext}
-          apiKey={innerSettings.apiKey!}
+          sdkKey={innerSettings.sdkKey!}
         >
           <InnerUserComponent />
         </ReforgeProvider>
@@ -99,7 +99,7 @@ function App({
 }) {
   return (
     <ReforgeProvider
-      apiKey={apiKey}
+      sdkKey={sdkKey}
       contextAttributes={outerUserContext}
       onError={onError}
       // eslint-disable-next-line react/jsx-boolean-value
@@ -173,7 +173,7 @@ it("allows nested `ReforgeProvider`s that reuse the parent provider's settings",
 
   expect(outerReforgeWrapper.getAttribute("data-reforge-settings")).toStrictEqual(
     JSON.stringify({
-      apiKey,
+      sdkKey,
       collectEvaluationSummaries: false,
       onError,
     })
@@ -182,7 +182,7 @@ it("allows nested `ReforgeProvider`s that reuse the parent provider's settings",
   // These are all inherited
   expect(innerReforgeWrapper.getAttribute("data-reforge-settings")).toStrictEqual(
     JSON.stringify({
-      apiKey,
+      sdkKey,
       collectEvaluationSummaries: false,
       onError,
     })
@@ -224,7 +224,7 @@ it("allows nested `ReforgeProvider`s that use new settings", async () => {
   });
 
   const innerProviderSettings = {
-    apiKey: "inner-api-key",
+    sdkKey: "inner-sdk-key",
     collectLoggerNames: true,
   };
 
@@ -251,7 +251,7 @@ it("allows nested `ReforgeProvider`s that use new settings", async () => {
 
   expect(outerReforgeWrapper.getAttribute("data-reforge-settings")).toStrictEqual(
     JSON.stringify({
-      apiKey,
+      sdkKey,
       collectEvaluationSummaries: false,
       onError,
     })
@@ -260,7 +260,7 @@ it("allows nested `ReforgeProvider`s that use new settings", async () => {
   // These are NOT inherited so we get what we set on the inner provider
   expect(innerReforgeWrapper.getAttribute("data-reforge-settings")).toStrictEqual(
     JSON.stringify({
-      apiKey: "inner-api-key",
+      sdkKey: "inner-sdk-key",
       collectLoggerNames: true,
     })
   );

--- a/src/__tests__/nested-test-providers.test.tsx
+++ b/src/__tests__/nested-test-providers.test.tsx
@@ -75,7 +75,7 @@ function OuterUserComponent({
           config={innerTestConfig}
           /* eslint-disable-next-line react/jsx-props-no-spreading */
           {...settings}
-          apiKey={settings.apiKey!}
+          sdkKey={settings.sdkKey!}
           contextAttributes={{ user: { email: "test@example.com" } }}
         >
           <InnerUserComponent />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,12 +1083,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reforge-com/javascript@npm:^0.0.0-pre.3":
-  version: 0.0.0-pre.3
-  resolution: "@reforge-com/javascript@npm:0.0.0-pre.3"
+"@reforge-com/javascript@npm:^0.0.0-pre.4":
+  version: 0.0.0-pre.4
+  resolution: "@reforge-com/javascript@npm:0.0.0-pre.4"
   dependencies:
     uuid: "npm:^9.0.1"
-  checksum: 10c0/443e75c1736f45e6b93ad9b8ae0162cb4d395f815ab4fd89a61b2f07c25a107923439a26d8c8bb89ade94e943c62ba88588aa93967ceb3bb0f7d238ffe510ce5
+  checksum: 10c0/52361eda81d30bbbab93019c5ca10f9eb820cb6e7d90d72bce40019bf667789c085dcab6f6c24c73682ae56dc06d86704a85d8dd4c05fa5709bd0c33519201a1
   languageName: node
   linkType: hard
 
@@ -1096,7 +1096,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@reforge-com/react@workspace:."
   dependencies:
-    "@reforge-com/javascript": "npm:^0.0.0-pre.3"
+    "@reforge-com/javascript": "npm:^0.0.0-pre.4"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^13.3.0"
     "@types/jest": "npm:^28.1.6"


### PR DESCRIPTION
## Summary
- Update dependency to `@reforge-com/javascript` v0.0.0-pre.4
- Rename all `apiKey` references to `sdkKey` throughout the codebase for API consistency
- Bump package version to 0.0.0-pre.6

## Changes
- **Dependency Update**: Updated `@reforge-com/javascript` from v0.0.0-pre.3 to v0.0.0-pre.4
- **API Rename**: Changed `apiKey` prop/parameter to `sdkKey` in:
  - `ReforgeProvider` and `ReforgeTestProvider` interfaces
  - All test files and test data
  - Documentation in README.md
- **Version Bump**: Updated package version to 0.0.0-pre.6

## Test plan
- [x] All existing tests pass with renamed parameters
- [x] TypeScript compilation succeeds
- [x] Documentation updated to reflect new parameter names
- [x] Dependency update aligns with JavaScript SDK changes

🤖 Generated with [Claude Code](https://claude.ai/code)